### PR TITLE
Single save button for saving plots PNG/SVG

### DIFF
--- a/R/glimmaXY.R
+++ b/R/glimmaXY.R
@@ -88,7 +88,7 @@ buildXYData <- function(
     counts <- data.frame(counts)
     #if (is.null(groups)) stop("If counts arg is supplied, groups arg must be non-null.")
     if (is.null(groups)) {
-      groups <- factor("samples")
+      groups <- factor("group")
     } else {
       if (ncol(counts) != length(groups)) stop("Length of groups must be equal to the number of columns in counts.\n")
     }

--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -75,13 +75,10 @@ HTMLWidgets.widget({
         };
 
         setupXYInteraction(data);
-        addSavePlotButton(controlContainer, xyView, text="Save (XY)");
-        if (expressionView)
-        {
-          addSavePlotButton(controlContainer, expressionView, text="Save (EXP)");
+        addSavePlotButton(controlContainer, xyView, expressionView, "Save Plot");
+        if (expressionView) {
           addAxisMessage(data);
         }
-
       },
 
       resize: function(width, height) 

--- a/inst/htmlwidgets/lib/GlimmaV2/XYSpecs.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/XYSpecs.js
@@ -8,7 +8,7 @@ function createXYSpec(xyData, xyTable, width, height)
     "description": "Testing ground for GlimmaV2",
     "width": xyData.counts == -1 ? (width*0.9) : (width * 0.5),
     "height": height * 0.35,
-    "padding": 0,
+    "padding": {"left": 0, "top": 0, "right": 0, "bottom": 10},
     "autosize": {"type": "fit", "resize": true},
     "title": {
       "text": xyData.title
@@ -81,7 +81,7 @@ function createXYSpec(xyData, xyTable, width, height)
         "domain": false,
         "orient": "bottom",
         "tickCount": 5,
-        "title": xyData.x,
+        "title": xyData.x
       },
       {
         "scale": "y",

--- a/inst/htmlwidgets/lib/GlimmaV2/expressionSpec.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/expressionSpec.js
@@ -8,7 +8,7 @@ function createExpressionSpec(width, height, expColumns, sampleColours)
         "$schema": "https://vega.github.io/schema/vega/v5.json",
         "width": width*0.40,
         "height": height*0.35,
-        "padding": 0,
+        "padding": {"left": 0, "top": 0, "right": 0, "bottom": 10},
         "autosize": {"type": "fit", "resize": true},
         "title": { "text": {"signal": "title_signal" }},
         "signals": 
@@ -65,7 +65,7 @@ function createExpressionSpec(width, height, expColumns, sampleColours)
                 "title": "group",
                 "labelAngle": -45,
                 "labelAlign": "right",
-                "labelOffset": -3
+                "labelOffset": -3  
             },
             {
                 "scale": "y",

--- a/inst/htmlwidgets/lib/GlimmaV2/saveTools.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/saveTools.js
@@ -1,4 +1,4 @@
-function addSavePlotButton(controlContainer, view_obj, text="Save Plot")
+function addSavePlotButton(controlContainer, xy_obj, exp_obj, text="Save Plot") 
 {
   // set up button elements
   var dropdownDiv = document.createElement("div");
@@ -11,38 +11,24 @@ function addSavePlotButton(controlContainer, view_obj, text="Save Plot")
   var dropdownContent = document.createElement("div");
   dropdownContent.setAttribute("class", "dropdown-content");
   
-  var pngSaveBtn = document.createElement("a");
-  pngSaveBtn.setAttribute("href", "#")
-  pngSaveBtn.innerText = "PNG";
-  pngSaveBtn.onclick = function() {
-    view_obj.toImageURL('png', scaleFactor=3).then(function (url) {
-      var link = document.createElement('a');
-      link.setAttribute('href', url);
-      link.setAttribute('target', '_blank');
-      link.setAttribute('download', 'vega-export.png');
-      link.dispatchEvent(new MouseEvent('click'));
-    });
-  };
+  var pngSummaryBtn = addSaveButtonElement(xy_obj, text="Summary plot (PNG)", type='png');
+  var svgSummaryBtn = addSaveButtonElement(xy_obj, text="Summary plot (SVG)", type='png');
   
-  var svgSaveBtn = document.createElement("a");
-  svgSaveBtn.setAttribute("href", "#");
-  svgSaveBtn.innerText = "SVG";
-  svgSaveBtn.onclick = function() {
-    view_obj.toImageURL('svg', scaleFactor=3).then(function (url) {
-      var link = document.createElement('a');
-      link.setAttribute('href', url);
-      link.setAttribute('target', '_blank');
-      link.setAttribute('download', 'vega-export.svg');
-      link.dispatchEvent(new MouseEvent('click'));
-    });
-  };
-
   // add elements to container
   dropdownDiv.appendChild(dropdownButton);
   dropdownDiv.appendChild(dropdownContent);
 
-  dropdownContent.appendChild(pngSaveBtn);
-  dropdownContent.appendChild(svgSaveBtn);
+  dropdownContent.appendChild(pngSummaryBtn);
+  dropdownContent.appendChild(svgSummaryBtn);
+
+  // add the expression buttons if expression plot is active
+  if (exp_obj) {
+    var pngExpressionBtn = addSaveButtonElement(exp_obj, text="Expression plot (PNG)", type='png');
+    var svgExpressionBtn = addSaveButtonElement(exp_obj, text="Expression plot (SVG)", type='svg');
+  
+    dropdownContent.appendChild(pngExpressionBtn);
+    dropdownContent.appendChild(svgExpressionBtn);
+  }
 
   // set up dropdown action
   dropdownButton.onclick = function() {
@@ -78,6 +64,22 @@ function addSavePlotButton(controlContainer, view_obj, text="Save Plot")
   }
 }
 
+function addSaveButtonElement(view_obj, text, type) {
+  // create a save button element for the save dropdown
+  var saveButton = document.createElement("a");
+  saveButton.setAttribute("href", "#")
+  saveButton.innerText = text;
+  saveButton.onclick = function() {
+    view_obj.toImageURL(type, scaleFactor=3).then(function (url) {
+      var link = document.createElement('a');
+      link.setAttribute('href', url);
+      link.setAttribute('target', '_blank');
+      link.setAttribute('download', 'vega-export.' + type);
+      link.dispatchEvent(new MouseEvent('click'));
+    });
+  };
+  return saveButton;
+}
 
 function saveTableClickListener(state, data)
 {


### PR DESCRIPTION
- changed the Save Plot (SVG) and Save Plot (PNG) buttons to a single Save Plot button, which displays a dropdown list of the possible save methods for the summary and expression plots.
- Adjusted the padding around the summary and expression plots in order to not cut off expression and summary x axis labels
-  Changed name for group containing all samples when groups argument is NULL