### PR TITLE
Added options to transform.counts argument

### DIFF
--- a/R/glimmaMA.R
+++ b/R/glimmaMA.R
@@ -66,7 +66,7 @@ glimmaMA <- function(x, ...)
 #' unspecified, samples will be coloured according to \code{groups}.
 #'
 #' @param p.adj.method character string specifying p-value adjustment method.
-#' @param transform.counts TRUE if counts should be log-cpm transformed using
+#' @param transform.counts the type of transform used on the counts log-cpm by default.
 #' \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.
 #'
 #' @param main character string for the main title of summary plot.
@@ -92,7 +92,7 @@ glimmaMA.MArrayLM <- function(
   status.cols=c("dodgerblue", "silver", "firebrick"),
   sample.cols=NULL,
   p.adj.method = "BH",
-  transform.counts=FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main=colnames(x)[coef],
   xlab="logCPM",
   ylab="logFC",
@@ -100,6 +100,7 @@ glimmaMA.MArrayLM <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   # check if the number of rows of x and the dge object are equal
   if (nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
 
@@ -143,7 +144,7 @@ glimmaMA.DGEExact <- function(
   status.cols=c("dodgerblue", "silver", "firebrick"),
   sample.cols=NULL,
   p.adj.method = "BH",
-  transform.counts=FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main=paste(x$comparison[2],"vs",x$comparison[1]),
   xlab="logCPM",
   ylab="logFC",
@@ -151,6 +152,7 @@ glimmaMA.DGEExact <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   # check if the number of rows of x and the dge object are equal
   if (nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
 
@@ -204,7 +206,7 @@ glimmaMA.DESeqDataSet  <- function(
   display.columns = NULL,
   status.cols=c("dodgerblue", "silver", "firebrick"),
   sample.cols=NULL,
-  transform.counts=FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main="MA Plot",
   xlab="logCPM",
   ylab="logFC",
@@ -212,6 +214,7 @@ glimmaMA.DESeqDataSet  <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   res.df <- as.data.frame(DESeq2::results(x))
 
   # filter out genes that have missing data

--- a/R/glimmaMDS.R
+++ b/R/glimmaMDS.R
@@ -250,7 +250,12 @@ glimmaMDS.DGEList <- function(
   width = 900,
   height = 500)
 {
-  if (length(groups) != ncol(x)) stop ("Length of groups argument must equal the number of columns in the DGE object")
+  if (is.vector(groups) && (length(groups) != ncol(x))) {
+    stop("length of groups argument must equal the number of columns in the DGE object")
+  }
+  if (is.data.frame(groups) && nrow(groups) != ncol(x)) {
+    stop("number of rows in groups argument must equal the number of columns in the DGE object")
+  }
   if (is.null(labels))
   {
     labels <- as.character(seq_len(ncol(x)))
@@ -271,7 +276,7 @@ glimmaMDS.DGEList <- function(
 
 #' Glimma MDS Plot
 #'
-#' Draws a two-panel interactive MDS plot using a DESeqDataset x. 
+#' Draws a two-panel interactive MDS plot using a DESeqDataset x.
 #' Transforms counts using \code{edgeR::cpm(DESeq2::counts(x), log = TRUE, prior.count = prior.count)}.
 #'
 #' @seealso \code{\link{glimmaMDS}}, \code{\link{glimmaMDS.default}}, \code{\link{glimmaMDS.DGEList}}

--- a/R/glimmaVolcano.R
+++ b/R/glimmaVolcano.R
@@ -40,7 +40,7 @@ glimmaVolcano.MArrayLM <- function(
   status.cols=c("dodgerblue", "silver", "firebrick"),
   sample.cols=NULL,
   p.adj.method = "BH",
-  transform.counts=FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main=colnames(x)[coef],
   xlab="logFC",
   ylab="negLog10PValue",
@@ -48,6 +48,7 @@ glimmaVolcano.MArrayLM <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   table <- data.frame(signif(unname(x$coefficients[, coef]), digits=4),
                       signif( -log10(x$p.value[, coef]), digits=4))
   colnames(table) <- c(xlab, ylab)
@@ -82,7 +83,7 @@ glimmaVolcano.DGEExact <- function(
   status.cols=c("dodgerblue", "silver", "firebrick"),
   sample.cols=NULL,
   p.adj.method = "BH",
-  transform.counts=FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main=paste(x$comparison[2],"vs",x$comparison[1]),
   xlab="logFC",
   ylab="negLog10PValue",
@@ -90,6 +91,7 @@ glimmaVolcano.DGEExact <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   # create initial table with -log10(pvalue) and logFC features
   table <- data.frame(signif(x$table$logFC, digits=4),
                       signif(-log10(x$table$PValue), digits=4))
@@ -136,7 +138,7 @@ glimmaVolcano.DESeqDataSet  <- function(
   display.columns = NULL,
   status.cols=c("dodgerblue", "silver", "firebrick"),
   sample.cols=NULL,
-  transform.counts=FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main="Volcano Plot",
   xlab="logFC",
   ylab="negLog10PValue",
@@ -144,6 +146,7 @@ glimmaVolcano.DESeqDataSet  <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   res.df <- as.data.frame(DESeq2::results(x))
 
   # filter out genes that have missing data

--- a/R/glimmaXY.R
+++ b/R/glimmaXY.R
@@ -33,6 +33,7 @@ glimmaXY <- function(
   width = 920,
   height = 920)
 {
+  transform.counts <- match.arg(transform.counts)
   if (length(x)!=length(y)) stop("Error: x and y args must have the same length.")
   table <- data.frame(signif(x, digits=4), signif(y, digits=4))
   colnames(table) <- c(xlab, ylab)
@@ -83,12 +84,27 @@ buildXYData <- function(
     level <- NULL
   } else {
     # df format for serialisation
-    if (transform.counts) {
-      if (!all.equal(counts, as.integer(counts))) {
+    if (transform.counts != "none") {
+      if (!all.equal(counts, round(counts))) {
         warning("count transform requested but not all count values are integers.")
       }
-      counts <- edgeR::cpm(counts, log=TRUE)
+
+      if (transform.counts == "logcpm") {
+        counts <- edgeR::cpm(counts, log=TRUE)
+      } else if (transform.counts == "cpm") {
+        counts <- edgeR::cpm(counts, log=FALSE)
+      } else if (transform.counts == "rpkm") {
+        if (is.null(anno$length)) {
+          stop("no 'length' column in gene annotation, rpkm cannot be computed")
+        }
+
+        if (!is.numeric(anno$length)) {
+          stop("'length' column of gene annotation must be numeric values")
+        }
+        counts <- edgeR::rpkm(counts, gene.length = anno$length)
+      }
     }
+
     counts <- data.frame(counts)
     #if (is.null(groups)) stop("If counts arg is supplied, groups arg must be non-null.")
     if (is.null(groups)) {

--- a/man/buildXYData.Rd
+++ b/man/buildXYData.Rd
@@ -53,7 +53,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 \item{groups}{vector of length \code{ncol(dge)} representing categorisation of samples in
 expression plot.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 }
 \value{

--- a/man/glimmaMA.DESeqDataSet.Rd
+++ b/man/glimmaMA.DESeqDataSet.Rd
@@ -13,7 +13,7 @@
   display.columns = NULL,
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = "MA Plot",
   xlab = "logCPM",
   ylab = "logFC",
@@ -43,7 +43,7 @@ with \code{status}  in the order of -1, 0 and 1.}
 for colours associated with each sample to be displayed on the expression plot. If left
 unspecified, samples will be coloured according to \code{groups}.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaMA.DGEExact.Rd
+++ b/man/glimmaMA.DGEExact.Rd
@@ -15,7 +15,7 @@
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
   p.adj.method = "BH",
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = paste(x$comparison[2], "vs", x$comparison[1]),
   xlab = "logCPM",
   ylab = "logFC",
@@ -57,7 +57,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 
 \item{p.adj.method}{character string specifying p-value adjustment method.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaMA.DGELRT.Rd
+++ b/man/glimmaMA.DGELRT.Rd
@@ -15,7 +15,7 @@
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
   p.adj.method = "BH",
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = paste(x$comparison[2], "vs", x$comparison[1]),
   xlab = "logCPM",
   ylab = "logFC",
@@ -57,7 +57,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 
 \item{p.adj.method}{character string specifying p-value adjustment method.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaMA.MArrayLM.Rd
+++ b/man/glimmaMA.MArrayLM.Rd
@@ -16,7 +16,7 @@
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
   p.adj.method = "BH",
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = colnames(x)[coef],
   xlab = "logCPM",
   ylab = "logFC",
@@ -62,7 +62,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 
 \item{p.adj.method}{character string specifying p-value adjustment method.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaMDS.DESeqDataSet.Rd
+++ b/man/glimmaMDS.DESeqDataSet.Rd
@@ -46,7 +46,7 @@ raw counts are transformed to log-counts-per-million values.}
 htmlwidget object or \code{NULL} if \code{html} argument is specified.
 }
 \description{
-Draws a two-panel interactive MDS plot using a DESeqDataset x. 
+Draws a two-panel interactive MDS plot using a DESeqDataset x.
 Transforms counts using \code{edgeR::cpm(DESeq2::counts(x), log = TRUE, prior.count = prior.count)}.
 }
 \details{

--- a/man/glimmaVolcano.DESeqDataSet.Rd
+++ b/man/glimmaVolcano.DESeqDataSet.Rd
@@ -13,7 +13,7 @@
   display.columns = NULL,
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = "Volcano Plot",
   xlab = "logFC",
   ylab = "negLog10PValue",
@@ -43,7 +43,7 @@ with \code{status}  in the order of -1, 0 and 1.}
 for colours associated with each sample to be displayed on the expression plot. If left
 unspecified, samples will be coloured according to \code{groups}.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaVolcano.DGEExact.Rd
+++ b/man/glimmaVolcano.DGEExact.Rd
@@ -15,7 +15,7 @@
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
   p.adj.method = "BH",
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = paste(x$comparison[2], "vs", x$comparison[1]),
   xlab = "logFC",
   ylab = "negLog10PValue",
@@ -57,7 +57,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 
 \item{p.adj.method}{character string specifying p-value adjustment method.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaVolcano.DGELRT.Rd
+++ b/man/glimmaVolcano.DGELRT.Rd
@@ -15,7 +15,7 @@
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
   p.adj.method = "BH",
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = paste(x$comparison[2], "vs", x$comparison[1]),
   xlab = "logFC",
   ylab = "negLog10PValue",
@@ -57,7 +57,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 
 \item{p.adj.method}{character string specifying p-value adjustment method.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaVolcano.MArrayLM.Rd
+++ b/man/glimmaVolcano.MArrayLM.Rd
@@ -16,7 +16,7 @@
   status.cols = c("dodgerblue", "silver", "firebrick"),
   sample.cols = NULL,
   p.adj.method = "BH",
-  transform.counts = FALSE,
+  transform.counts = c("logcpm", "cpm", "rpkm", "none"),
   main = colnames(x)[coef],
   xlab = "logFC",
   ylab = "negLog10PValue",
@@ -62,7 +62,7 @@ unspecified, samples will be coloured according to \code{groups}.}
 
 \item{p.adj.method}{character string specifying p-value adjustment method.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}

--- a/man/glimmaXY.Rd
+++ b/man/glimmaXY.Rd
@@ -53,7 +53,7 @@ with \code{status}  in the order of -1, 0 and 1.}
 for colours associated with each sample to be displayed on the expression plot. If left
 unspecified, samples will be coloured according to \code{groups}.}
 
-\item{transform.counts}{TRUE if counts should be log-cpm transformed using
+\item{transform.counts}{the type of transform used on the counts log-cpm by default.
 \code{edgeR::cpm(counts, log=TRUE)}; defaults to FALSE.}
 
 \item{main}{character string for the main title of summary plot.}


### PR DESCRIPTION
* The `transform.counts` argument in XY and MA plots can now be set to one of logcpm, cpm, rkpm or none.
    * Choosing the rpkm option requires that the `length` column be present in the gene annotations.
* Fixed bug in argument dimension checking in MDS plot.