### PR TITLE
changing transform defaults

### DIFF
--- a/R/glimmaMA.R
+++ b/R/glimmaMA.R
@@ -125,9 +125,15 @@ glimmaMA.MArrayLM <- function(
   height = 920,
   ...)
 {
+
+  # check if user counts are given
+  if (is.null(dge) && !is.null(counts)) {
+    message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
+  }
+
   transform.counts <- match.arg(transform.counts)
   # check if the number of rows of x and the dge object are equal
-  if (nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
 
   # create initial table with logCPM and logFC features
   table <- data.frame(signif(unname(x$Amean), digits=4),
@@ -193,9 +199,15 @@ glimmaMA.DGEExact <- function(
   height = 920,
   ...)
 {
+
+  # check if user counts are given
+  if (is.null(dge) && !is.null(counts)) {
+    message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
+  }
+
   transform.counts <- match.arg(transform.counts)
   # check if the number of rows of x and the dge object are equal
-  if (nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
 
   table <- data.frame(signif(x$table$logCPM, digits=4),
                       signif(x$table$logFC, digits=4))

--- a/R/glimmaMA.R
+++ b/R/glimmaMA.R
@@ -133,7 +133,7 @@ glimmaMA.MArrayLM <- function(
 
   transform.counts <- match.arg(transform.counts)
   # check if the number of rows of x and the dge object are equal
-  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("MArrayLM object must have equal rows/genes to DGEList.")
 
   # create initial table with logCPM and logFC features
   table <- data.frame(signif(unname(x$Amean), digits=4),
@@ -207,7 +207,7 @@ glimmaMA.DGEExact <- function(
 
   transform.counts <- match.arg(transform.counts)
   # check if the number of rows of x and the dge object are equal
-  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("DGEExact/DGELRT object must have equal rows/genes to DGEList.")
 
   table <- data.frame(signif(x$table$logCPM, digits=4),
                       signif(x$table$logFC, digits=4))

--- a/R/glimmaVolcano.R
+++ b/R/glimmaVolcano.R
@@ -65,6 +65,12 @@ glimmaVolcano.MArrayLM <- function(
   height = 920,
   ...)
 {
+
+  # check if user counts are given
+  if (is.null(dge) && !is.null(counts)) {
+    message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
+  }
+
   transform.counts <- match.arg(transform.counts)
   table <- data.frame(signif(unname(x$coefficients[, coef]), digits=4),
                       signif( -log10(x$p.value[, coef]), digits=4))
@@ -124,6 +130,12 @@ glimmaVolcano.DGEExact <- function(
   height = 920,
   ...)
 {
+
+  # check if user counts are given
+  if (is.null(dge) && !is.null(counts)) {
+    message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
+  }
+
   transform.counts <- match.arg(transform.counts)
   # create initial table with -log10(pvalue) and logFC features
   table <- data.frame(signif(x$table$logFC, digits=4),

--- a/R/glimmaVolcano.R
+++ b/R/glimmaVolcano.R
@@ -71,7 +71,7 @@ glimmaVolcano.MArrayLM <- function(
     message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
   }
 
-  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("MArrayLM object must have equal rows/genes to DGEList.")
 
   transform.counts <- match.arg(transform.counts)
   table <- data.frame(signif(unname(x$coefficients[, coef]), digits=4),
@@ -138,7 +138,7 @@ glimmaVolcano.DGEExact <- function(
     message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
   }
 
-  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("DGEExact/DGELRT object must have equal rows/genes to DGEList.")
 
   transform.counts <- match.arg(transform.counts)
   # create initial table with -log10(pvalue) and logFC features

--- a/R/glimmaVolcano.R
+++ b/R/glimmaVolcano.R
@@ -71,6 +71,8 @@ glimmaVolcano.MArrayLM <- function(
     message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
   }
 
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
+
   transform.counts <- match.arg(transform.counts)
   table <- data.frame(signif(unname(x$coefficients[, coef]), digits=4),
                       signif( -log10(x$p.value[, coef]), digits=4))
@@ -135,6 +137,8 @@ glimmaVolcano.DGEExact <- function(
   if (is.null(dge) && !is.null(counts)) {
     message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
   }
+
+  if (!is.null(dge) && nrow(x) != nrow(dge)) stop("Summary object must have equal rows/genes to expression object.")
 
   transform.counts <- match.arg(transform.counts)
   # create initial table with -log10(pvalue) and logFC features

--- a/R/glimmaXY.R
+++ b/R/glimmaXY.R
@@ -52,6 +52,12 @@ glimmaXY <- function(
   width = 920,
   height = 920)
 {
+
+  # check if user counts are given
+  if (is.null(dge) && !is.null(counts)) {
+    message("External counts supplied using counts argument will be transformed to log-cpm by default. Specify transform.counts='none' to override transformation.")
+  }
+
   transform.counts <- match.arg(transform.counts)
   if (length(x)!=length(y)) stop("Error: x and y args must have the same length.")
   table <- data.frame(signif(x, digits=4), signif(y, digits=4))

--- a/tests/testthat/test-glimmaMA.R
+++ b/tests/testthat/test-glimmaMA.R
@@ -40,7 +40,7 @@ test_that("MA Plot returns widget",
     expect_equal(is.null(result), FALSE)
 })
 
-test_that("Saving MA plot works",
+test_that("HTML arg exports the MA plot",
 {
     testname <- "testMAabc.html"
     # MArrayLM, DGEExact/DGELRT
@@ -83,11 +83,12 @@ test_that("Length of status vector must match the other args",
     expect_message(glimmaMA(dds, status=rep(0, nrow(dds))), "genes were filtered out in DESeq2 tests")
 })
 
-test_that("User cannot provide counts argument without groups argument for edgeR/limma objects",
+test_that("DGE argument must have same length as limma/edgeR objects",
 {
+    sample <- 1:(nrow(dge)-10)
     # MArrayLM, DGEExact/DGELRT
     for (x in list(limmaFit, dgeexact))
     {
-        expect_error(glimmaMA(x, counts=dge$counts))
+        expect_error(glimmaMA(x, counts=dge[sample,]))
     }
 })

--- a/tests/testthat/test-glimmaVolcano.R
+++ b/tests/testthat/test-glimmaVolcano.R
@@ -57,3 +57,14 @@ test_that("Saving volcano plot works",
     expect_equal(file.exists(testname), TRUE)
     unlink(testname)
 })
+
+
+test_that("DGE argument must have same length as limma/edgeR objects",
+{
+    sample <- 1:(nrow(dge)-10)
+    # MArrayLM, DGEExact/DGELRT
+    for (x in list(limmaFit, dgeexact))
+    {
+        expect_error(glimmaVolcano(x, counts=dge[sample,]))
+    }
+})

--- a/tests/testthat/test-glimmaXY.R
+++ b/tests/testthat/test-glimmaXY.R
@@ -35,3 +35,14 @@ test_that("X and Y args must have the same length",
     expect_error(glimmaXY(x=1:3, y=1:4))
     expect_silent(glimmaXY(x=1:4, y=1:4))
 })
+
+test_that("Groups arg can be omitted without error",
+{
+    result <- glimmaXY(x=fc, y =sig, counts=dge$counts)
+    expect_equal(is.null(result), FALSE)
+})
+
+test_that("Length of groups must match the no. of columns in counts",
+{
+    expect_error(glimmaXY(x=fc, y =sig, counts=dge$counts, groups=1:(ncol(lymphomaRNAseq)-1)))
+})


### PR DESCRIPTION
- in this PR, we implement the following behaviour for the glimmaMA, glimmaXY and glimmaVolcano functions:
    - if the ```dge``` arg is non-null, log-transform ```dge$counts``` as usual
    - however, if the ```dge``` argument is null but separate ```counts``` is non-null, warn the user that the counts will be log-transformed unless specified otherwise with the ```transform.counts``` arg