### PR TITLE
colourscheme dropdown for exp plot

### DIFF
--- a/inst/htmlwidgets/glimmaMDS.js
+++ b/inst/htmlwidgets/glimmaMDS.js
@@ -67,7 +67,6 @@ HTMLWidgets.widget({
         addSavePlotButton(controlContainer, mdsView, eigenView, text="Save Plot",
                           summaryText="MDS", expressionText="VAR");
 
-        reformatElementsMDS(controlContainer);
       },
 
       resize: function(width, height)
@@ -83,7 +82,6 @@ function addBlockElement(controlContainer)
   blockElement.setAttribute("class", "display-block");
   controlContainer.appendChild(blockElement);
 }
-
 
 function processDataMDS(x)
 {
@@ -118,20 +116,6 @@ function linkPlotsMDS(mdsView, eigenView)
     eigenView.runAsync();
   });
 
-}
-
-/* arranges vega-bind elements so that x_dim, y_dim are on their
-   own line */
-function reformatElementsMDS(controlContainer)
-{
-  var binds = controlContainer.getElementsByClassName("vega-bind");
-  for (var i = 0; i < binds.length; i++)
-  {
-    // the separator input signal is a dummy invisible signal after x_axis, y_axis
-    if (i == 2) binds[i].className += " separator_signal";
-    // it is used to display all signals after x_axis, y_axis to display on a different line
-    else if (i > 2) binds[i].className += " signal";
-  }
 }
 
 function addColourMessage(data, view, container)

--- a/inst/htmlwidgets/glimmaXY.yaml
+++ b/inst/htmlwidgets/glimmaXY.yaml
@@ -1,4 +1,11 @@
 dependencies:
+  - name: datatables
+    version: 1.0
+    src: htmlwidgets/lib/datatables
+    script:
+      - datatables.min.js
+    stylesheet:
+      - datatables.css
   - name: vega
     version: 1.0
     src: htmlwidgets/lib/vega
@@ -13,13 +20,6 @@ dependencies:
       - vega-tooltip.js
     stylesheet:
       - vega-tooltip.css
-  - name: datatables
-    version: 1.0
-    src: htmlwidgets/lib/datatables
-    script:
-      - datatables.min.js
-    stylesheet:
-      - datatables.css
   - name: FileSaver
     version: 1.0
     src: htmlwidgets/lib/FileSaver

--- a/inst/htmlwidgets/lib/GlimmaV2/MDSSpecs.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/MDSSpecs.js
@@ -42,12 +42,6 @@ function createMDSSpec(mdsData, dimList, features, width, height, continuousColo
           "value": dimList[1],
           "bind": { "input": "select", "options": dimList }
         },
-        /* dummy_signal is used for CSS styling */
-        {
-          "name": "dummy_signal",
-          "value": {},
-          "bind": { "input": "select", "options": [] }
-        },
         {
           "name": "scale_by",
           "value": features["numeric"][0],

--- a/inst/htmlwidgets/lib/GlimmaV2/expressionSpec.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/expressionSpec.js
@@ -1,9 +1,23 @@
 function createExpressionSpec(width, height, expColumns, sampleColours, samples)
 {
+
+    let colourscheme_signal = 
+    {
+        "name": "colourscheme",
+        "value": "category10",
+        "bind": { 
+                    "input": "select", 
+                    "options": [ "category10", "accent", "category20", "category20b", "category20c", "dark2", "paired", "pastel1", "pastel2", "set1", "set2", "set3", "tableau10", "tableau20"] 
+                }
+    };
+
+    /* need an empty signal if sample.cols argument has been supplied */
+    let samplecols_signal = { "name": "samplecols_active" };
+
     /* must match counts term in processExpression */
     expColumns.push("count");
     let tooltip = makeVegaTooltip(expColumns);
-    return {
+    let spec = {
         "$schema": "https://vega.github.io/schema/vega/v5.json",
         "width": width*0.40,
         "height": height*0.35,
@@ -26,12 +40,13 @@ function createExpressionSpec(width, height, expColumns, sampleColours, samples)
                     },
                     {
                         "name": "max_count",
-                        "value": 0,
+                        "value": 0
                     },
                     {
                         "name": "max_y",
                         "update": " (max_y_axis < max_count) ? null : max_y_axis"
-                    }
+                    },
+                    sampleColours == -1 ? colourscheme_signal : samplecols_signal
                 ],
         "data": [ {"name": "table"} ],
         "scales": 
@@ -53,8 +68,8 @@ function createExpressionSpec(width, height, expColumns, sampleColours, samples)
                 "name": "color",
                 "type": "ordinal",
                 "domain": sampleColours == -1 ? { "data": "table", "field": "group" } : samples,
-                "range": sampleColours == -1 ? { "scheme": "category10" } : sampleColours
-            },
+                "range": sampleColours == -1 ? { "scheme": { "signal": "colourscheme" } } : sampleColours
+            }
         ],
         "axes": 
         [
@@ -86,7 +101,7 @@ function createExpressionSpec(width, height, expColumns, sampleColours, samples)
                         "shape": {"value": "circle"},
                         "fill": { "scale": "color", "field": sampleColours == -1 ? "group" : "sample" },
                         "strokeWidth": {"value": 1},
-                        "opacity": {"value": 0.6},
+                        "opacity": {"value": 0.8},
                         "size": {"value": 100},
                         "stroke": {"value": "#575757"},
                         "tooltip": tooltip
@@ -94,5 +109,8 @@ function createExpressionSpec(width, height, expColumns, sampleColours, samples)
                 }
             }]
     };
+
+    console.log(spec);
+    return spec;
 
 }

--- a/inst/htmlwidgets/lib/GlimmaV2/expressionSpec.js
+++ b/inst/htmlwidgets/lib/GlimmaV2/expressionSpec.js
@@ -17,7 +17,7 @@ function createExpressionSpec(width, height, expColumns, sampleColours, samples)
     /* must match counts term in processExpression */
     expColumns.push("count");
     let tooltip = makeVegaTooltip(expColumns);
-    let spec = {
+    return {
         "$schema": "https://vega.github.io/schema/vega/v5.json",
         "width": width*0.40,
         "height": height*0.35,
@@ -109,8 +109,5 @@ function createExpressionSpec(width, height, expColumns, sampleColours, samples)
                 }
             }]
     };
-
-    console.log(spec);
-    return spec;
 
 }

--- a/inst/htmlwidgets/lib/vega/vega_plots.css
+++ b/inst/htmlwidgets/lib/vega/vega_plots.css
@@ -56,10 +56,6 @@
 
 /* custom styling for some inputs */
 
-.signal select {}
-
-/* custom styling for some inputs */
-
 .display-block {
 	display: block;
 }
@@ -165,14 +161,7 @@ button.save-button:active {
 	display: block;
 }
 
-/* vega max y axis setting */
-input .max_y_axis 
-{
-	margin-bottom: 5px;
-    margin-left: 5px;
-    border: solid 1px #b5b5b5;
-    border-radius: 2px;
-}
+
 
 .alertBox 
 {
@@ -203,4 +192,19 @@ input .max_y_axis
 	color: #721c24;
 	background-color: #f8d7da;
 	border: 1px solid #f5c6cb;
+}
+
+/* vega max y axis setting */
+input.max_y_axis
+{
+	margin-bottom: 5px;
+	margin-right: 10px;
+	border: solid 1px #b5b5b5;
+	border-radius: 2px;
+	display: block;
+}
+
+select
+{
+	display: block;
 }

--- a/tests/testthat/test-glimmaMA.R
+++ b/tests/testthat/test-glimmaMA.R
@@ -173,3 +173,16 @@ test_that("Setting transform.counts = rpkm transforms accordingly",
     }
     # can't test DESeq2 because some genes are filtered out
 })
+
+test_that("Display.columns arg provides a minimal set of [xlab, ylab, geneID]",
+{
+    # MArrayLM, DGEExact/DGELRT
+    for (x in list(limmaFit, dgeexact))
+    {
+        xData <- glimmaMA(x, dge=dge, xlab="x", ylab="y", display.columns=c("SYMBOL"))$x$data
+        expect_true(setequal(xData$cols, c("x", "y", "gene", "SYMBOL")))
+    }
+    # can't test DESeq2 because some genes are filtered out
+    xData <- glimmaMA(dds, xlab="x", ylab="y", display.columns=c("SYMBOL"))$x$data
+    expect_true(setequal(xData$cols, c("x", "y", "gene", "SYMBOL")))
+})


### PR DESCRIPTION
- the standard colourscheme for the expression plot is ```category10``` unless sample.cols is supplied, in which case the colour scheme is whatever the user gives
- this PR changes this behaviour so that:
    - a dropdown menu of *discrete* colourschemes appears when sample.cols is not provided (with ```category10``` as the first option)
    - otherwise, nothing appears