### PR TITLE
rounding max count

### DIFF
--- a/inst/htmlwidgets/glimmaXY.js
+++ b/inst/htmlwidgets/glimmaXY.js
@@ -332,7 +332,8 @@ function updateExpressionPlot(countsRow, data, geneName)
   }
   data.expressionView.data("table", result);
   data.expressionView.signal("title_signal", "Gene " + geneName.toString());
-  data.expressionView.signal("max_count", Math.max(...result.map(x => x.count)));
+  let max_value = Math.max(...result.map(x => x.count));
+  data.expressionView.signal("max_count", Math.round(max_value*100)/100 );
   data.expressionView.runAsync();
   updateAxisMessage(data);
 }


### PR DESCRIPTION
closing #58 

- using Math.round(num * 100)/100 to round num to 2 dec places can cause rounding errors (ex. 1.005 => 1, not 1.01 as expected) due to floating point representation issues
- however we don't require precision here, just giving the user an estimate of the max counts so they can adjust the parameter accordingly