### PR TITLE
Fix glimmaXY extraction of feature names

### DIFF
--- a/R/glimmaXY.R
+++ b/R/glimmaXY.R
@@ -65,10 +65,10 @@ glimmaXY <- function(
   # add rownames to LHS of table
   if (!is.null(counts)) {
     table <- cbind(gene=rownames(counts), table)
-  } else if (!is.null(rownames(x))) {
-    table <- cbind(gene=rownames(x), table)
-  } else if (!is.null(rownames(y))) {
-    table <- cbind(gene=rownames(y), table)
+  } else if (!is.null(names(x))) {
+    table <- cbind(gene=names(x), table)
+  } else if (!is.null(names(y))) {
+    table <- cbind(gene=names(y), table)
   } else {
     table <- cbind(gene=seq_along(x), table)
   }


### PR DESCRIPTION
Issue first raised here: #88 

According to documentation, `glimmaXY()` receives vectors as x and y axis input, yet it extracts feature names from these vectors using `rownames()`. This changes the function to extract feature names using `names()` instead of `rownames()`.

I also add that the example code for the documentation currently works as intended since `efit$coefficients` is actually a matrix with 1 column, not a vector. It might also be good to check if x and y are vectors and handle incorrect data types as an error or warning.

Thank you authors and maintainers for the great visualisation package, I just wanted to contribute in this small way.

Before fix (feature names are index in dataset):

![image](https://github.com/user-attachments/assets/cf417561-5903-489b-81e4-98bec3053f49)

After fix (feature names are now the supplied feature names (ENTREZ ID)):

![image](https://github.com/user-attachments/assets/2b6cb4e3-b46e-4841-96e9-6c9bd27b7023)
